### PR TITLE
Implement AIX builtin_cpu_is() 

### DIFF
--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -893,7 +893,7 @@ bool PPCTargetInfo::validateCpuIs(StringRef CPUName) const {
 #include "llvm/TargetParser/PPCTargetParser.def"
       .Default(false);
   } else if (Triple.isOSAIX()) {
-#define PPC_AIX_CPU(NAME, IN_SYSCON, HIGH16VALUE, ISLOW16ZERO) .Case(NAME, true)
+#define PPC_AIX_CPU(NAME, IN_SYSCON, HIGH16MAGIC, LOW16MAGIC) .Case(NAME, true)
     return llvm::StringSwitch<bool>(CPUName)
 #include "llvm/TargetParser/PPCTargetParser.def"
         .Default(false);

--- a/clang/lib/Basic/Targets/PPC.cpp
+++ b/clang/lib/Basic/Targets/PPC.cpp
@@ -886,8 +886,17 @@ bool PPCTargetInfo::validateCpuSupports(StringRef FeatureStr) const {
 }
 
 bool PPCTargetInfo::validateCpuIs(StringRef CPUName) const {
+  llvm::Triple Triple = getTriple();
+  if (Triple.isOSLinux()) {
 #define PPC_CPU(NAME, NUM) .Case(NAME, true)
   return llvm::StringSwitch<bool>(CPUName)
 #include "llvm/TargetParser/PPCTargetParser.def"
       .Default(false);
+  } else if (Triple.isOSAIX()) {
+#define PPC_AIX_CPU(NAME, IN_SYSCON, HIGH16VALUE, ISLOW16ZERO) .Case(NAME, true)
+    return llvm::StringSwitch<bool>(CPUName)
+#include "llvm/TargetParser/PPCTargetParser.def"
+        .Default(false);
+  }
+  return false;
 }

--- a/clang/lib/Basic/Targets/PPC.h
+++ b/clang/lib/Basic/Targets/PPC.h
@@ -363,7 +363,9 @@ public:
   // We support __builtin_cpu_supports/__builtin_cpu_is on targets that
   // have GLIBC since it is GLIBC that provides the HWCAP[2] in the auxv.
   bool supportsCpuSupports() const override { return getTriple().isOSGlibc(); }
-  bool supportsCpuIs() const override { return getTriple().isOSGlibc(); }
+  bool supportsCpuIs() const override {
+    return getTriple().isOSGlibc() || getTriple().isOSAIX();
+  }
   bool validateCpuSupports(StringRef Feature) const override;
   bool validateCpuIs(StringRef Name) const override;
 };

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -16425,12 +16425,12 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
 #include "llvm/TargetParser/PPCTargetParser.def"
               .Default({0, 0, 0});
       if (!IsCpuInAixSysConf)
-        // The CPU ID is not listed in _system_configuration of AIX OS, return
-        // false.
+        // If rhe CPU ID is not listed in _system_configuration of the AIX OS,
+        // return false.
         return llvm::ConstantInt::getFalse(ConvertType(E->getType()));
 
-      // In the extern variable _system_configuration of AIX OS. there is
-      // structure as:
+      // In the extern variable _system_configuration of the AIX OS. there is
+      // structure as follow:
       //  extern struct _system_conf {
       // int architecture;       /*processor architecture */
       // int implementation;     /* processor implementation */
@@ -16447,14 +16447,18 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       // Grab the appropriate field from _system_configuration.
       llvm::Value *Idxs[] = {ConstantInt::get(Int32Ty, 0),
                              ConstantInt::get(Int32Ty, AIX_SYSCON_VERSION_IDX)};
+#undef AIX_SYSCON_VERSION_IDX
+
       llvm::Value *CpuId = Builder.CreateGEP(STy, SysConf, Idxs);
       CpuId =
           Builder.CreateAlignedLoad(Int32Ty, CpuId, CharUnits::fromQuantity(4));
 
-      // In /usr/include/sys/systemcfg.h of AIX OS there is a defintion as:
+      // In /usr/include/sys/systemcfg.h of the AIX OS, there is a defintion
+      // as follow:
       // #define PV_5            0x0F0000        /* Power PC 5 */
       // #define PV_5_2          0x0F0001        /* Power PC 5 */
       // #define PV_5_3          0x0F0002        /* Power PC 5 */
+
       // builtin_cpu_is("power5") is true only when the value of version is
       // PV_5. builtin_cpu_is("power5+") is true only when the value of
       // version is PV_5_2 or PV_5_3.
@@ -16463,20 +16467,19 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       llvm::Value *CpuIdLow16 = Builder.CreateAnd(CpuId, 0x00000FFF);
       llvm::Value *Zero = llvm::Constant::getNullValue(Int32Ty);
 
-      // Check whether the high 16 bits match or not. for example, for
-      // example: builtin_cpu_is("power5"), it check whether the high 16 is
-      // 0x00f0.
+      // Check whether the high 16 bits match or not. For example:
+      // builtin_cpu_is("power5"), it checks whether the high 16 bits is 0x00f0
       Value *IsCpuHi16Match = Builder.CreateICmpEQ(
           CpuIdHi16, ConstantInt::get(Int32Ty, CpuHi16Magic));
 
-      // Check whether the low 16 bits match or not. if CpuLow16Magic is 1,
-      // the low 16 bits of version should be not zero. if if CpuLow16Magic
-      // is 0, the low 16 bits of version should be zero.
+      // Check whether the low 16 bits match or not. If CpuLow16Magic is 1,
+      // the low 16 bits of the version should not be zero. If CpuLow16Magic
+      // is 0, the low 16 bits of the version should be zero.
       Value *IsCpuLow16Match = Builder.CreateICmp(
           CpuLow16Magic ? ICmpInst::ICMP_NE : ICmpInst::ICMP_EQ, CpuIdLow16,
           Zero);
 
-      // Check the value of high 16 bit and low 16 both match the magic
+      // Check the value of high 16 bits and low 16 bits both match the magic.
       return Builder.CreateLogicalAnd(IsCpuLow16Match, IsCpuHi16Match);
     }
     LLVM_FALLTHROUGH;

--- a/clang/test/CodeGen/aix-builtin-cpu-is.cpp
+++ b/clang/test/CodeGen/aix-builtin-cpu-is.cpp
@@ -1,0 +1,43 @@
+// RUN: %clang_cc1 -triple powerpc-unknown-aix -emit-llvm -x c++ < %s | FileCheck %s
+
+bool isPower8() {
+  return __builtin_cpu_is("power8");
+}
+
+bool isPower5Plus() {
+  return __builtin_cpu_is("power5+");
+}
+
+bool isPower476() {
+  return __builtin_cpu_is("ppc476");
+}
+
+
+// CHECK:      @_system_configuration = external global { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i32, i32, i32, i32, i64, i64, i64, i64, i32, i32, i32, i32, i32, i32, i64, i32, i8, i8, i8, i8, i32, i32, i16, i16, [3 x i32], i32 }
+
+// CHECK:     define noundef zeroext i1 @_Z8isPower8v() #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %0 = load i32, ptr getelementptr inbounds ({ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i32, i32, i32, i32, i64, i64, i64, i64, i32, i32, i32, i32, i32, i32, i64, i32, i8, i8, i8, i8, i32, i32, i16, i16, [3 x i32], i32 }, ptr @_system_configuration, i32 0, i32 2), align 4
+// CHECK-NEXT:   %1 = lshr i32 %0, 16
+// CHECK-NEXT:   %2 = and i32 %0, 4095
+// CHECK-NEXT:   %3 = icmp eq i32 %1, 48
+// CHECK-NEXT:   %4 = icmp eq i32 %2, 0
+// CHECK-NEXT:   %5 = select i1 %4, i1 %3, i1 false
+// CHECK-NEXT:   ret i1 %5
+// CHECK-NEXT: }
+
+// CHECK:     define noundef zeroext i1 @_Z12isPower5Plusv() #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %0 = load i32, ptr getelementptr inbounds ({ i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i64, i32, i32, i32, i32, i64, i64, i64, i64, i32, i32, i32, i32, i32, i32, i64, i32, i8, i8, i8, i8, i32, i32, i16, i16, [3 x i32], i32 }, ptr @_system_configuration, i32 0, i32 2), align 4
+// CHECK-NEXT:   %1 = lshr i32 %0, 16
+// CHECK-NEXT:   %2 = and i32 %0, 4095
+// CHECK-NEXT:   %3 = icmp eq i32 %1, 15
+// CHECK-NEXT:   %4 = icmp ne i32 %2, 0
+// CHECK-NEXT:   %5 = select i1 %4, i1 %3, i1 false
+// CHECK-NEXT:   ret i1 %5
+// CHECK-NEXT: }
+
+// CHECK:      define noundef zeroext i1 @_Z10isPower476v() #0 {
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret i1 false
+// CHECK-NEXT: }

--- a/llvm/include/llvm/TargetParser/PPCTargetParser.def
+++ b/llvm/include/llvm/TargetParser/PPCTargetParser.def
@@ -78,3 +78,42 @@ PPC_CPU("power9",46)
 PPC_CPU("power10",47)
 #undef PPC_FEATURE
 #undef PPC_CPU
+
+#ifndef PPC_AIX_CPU
+#define PPC_AIX_CPU(NAME, IN_SYSCON, HIGH16MAGIC, LOW16MAGIC)
+#endif
+PPC_AIX_CPU("power4",1,0x000C,0)
+PPC_AIX_CPU("ppc970",0,0x0,0)
+PPC_AIX_CPU("power5",1,0x000f,0)
+PPC_AIX_CPU("power5+",1,0x000f,1)
+PPC_AIX_CPU("power6",1,0x0010,0)
+PPC_AIX_CPU("ppc-cell-be",0,0,0)
+PPC_AIX_CPU("power6x",1,0x0010,1)
+PPC_AIX_CPU("power7",1,0x0020,0)
+PPC_AIX_CPU("ppca2",0,0,0)
+PPC_AIX_CPU("ppc405",0,0,0)
+PPC_AIX_CPU("ppc440",0,0,0)
+PPC_AIX_CPU("ppc464",0,0,0)
+PPC_AIX_CPU("ppc476",0,0,0)
+PPC_AIX_CPU("power8",1,0x0030,0)
+PPC_AIX_CPU("power9",1,0x0040,0)
+PPC_AIX_CPU("power10",1,0x0050,0)
+#undef PPC_AIX_CPU
+
+#ifndef AIX_SYSCON_VERSION_IDX
+#define AIX_SYSCON_VERSION_IDX 2
+#endif
+
+#ifndef PPC_SYSTEMCONFIG_TYPE
+#define PPC_SYSTEMCONFIG_TYPE \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int64Ty, Int32Ty, Int32Ty, Int32Ty, \
+Int32Ty, Int64Ty, Int64Ty, Int64Ty, Int64Ty, Int32Ty, \
+Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int32Ty, Int64Ty, \
+Int32Ty, Int8Ty, Int8Ty, Int8Ty, Int8Ty, Int32Ty, \
+Int32Ty, Int16Ty, Int16Ty, llvm::ArrayType::get(Int32Ty,3), Int32Ty
+#endif


### PR DESCRIPTION
runtime external variable  `_system_configuration.version` of `/usr/include/sys/systemcfg.h`  provide all the information we need the function __builtin_cpu_is().
 
 it has structure like 
 
```
 extern struct _system_conf {
        int architecture;       /* processor architecture */
        int implementation;     /* processor implementation */
        int version;            /* processor version */
        .....
        }
```
it has some define as 

/* Values for the version field
 */
#define PV_601          0x010001        /* Power PC 601 */
#define PV_601a         0x010002        /* Power PC 601 */
#define PV_603          0x060000        /* Power PC 603 */
#define PV_604          0x050000        /* Power PC 604 */
#define PV_620          0x070000        /* Power PC 620 */
#define PV_630          0x080000        /* Power PC 630 */
#define PV_A35          0x090000        /* Power PC A35 */
#define PV_RS64II       0x0A0000        /* Power PC RS64II */
#define PV_RS64III      0x0B0000        /* Power PC RS64III */
#define PV_4            0x0C0000        /* Power PC 4 */
#define PV_RS64IV       PV_4            /* Power PC 4 */
#define PV_MPC7450      0x0D0000        /* Power PC MPC7450 */
#define PV_4_2          0x0E0000        /* Power PC 4 */
#define PV_4_3          0x0E0001        /* Power PC 4 */
#define PV_5            0x0F0000        /* Power PC 5 */
#define PV_5_2          0x0F0001        /* Power PC 5 */
#define PV_5_3          0x0F0002        /* Power PC 5 */
#define PV_6            0x100000        /* Power PC 6 */
#define PV_6_1          0x100001        /* Power PC 6 DD1.x */
#define PV_7            0x200000        /* Power PC 7 */
#define PV_8            0x300000        /* Power PC 8 */
#define PV_9            0x400000        /* Power PC 9 */
/*
 * The following Compat definitions indicate that the processor is running in
 * a mode that is compatible with the processor family as indicated by the
 * implementation field of the _system_configuration structure.  When running
 * in a compatible mode, BookIV processor features of that processor family
 * can not be assumed to be present or functional.
 */
#define PV_5_Compat     0x0F8000        /* Power PC 5 */
#define PV_6_Compat     0x108000        /* Power PC 6 */
#define PV_7_Compat     0x208000        /* Power PC 7 */
#define PV_8_Compat     0x308000        /* Power PC 8 */
#define PV_9_Compat     0x408000        /* Power PC 9 */


the High 16 bit of the version indicates  Power PC version
the version masked with  0x0000F000 indicates whether is in compatible mode 
the lowest 12 bit of the version indicates the Power PC sub version, Power4+ or Power5+. 